### PR TITLE
Add Enable Media Replace

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -4,3 +4,4 @@ pressbooks-mpdf
 pressbooks-textbook
 tablepress
 wp-quicklatex
+enable-media-replace


### PR DESCRIPTION
Adds Enable Media Replace to the list of Pressbooks recommended plugins.